### PR TITLE
解决多次new bsgrid对象时，存在多个翻页工具栏的问题

### DIFF
--- a/sources/js/grid.js
+++ b/sources/js/grid.js
@@ -1045,6 +1045,11 @@
                 pagingOutTabSb.append($.bsgridLanguage.noPagingation(options.noPagingationId) + '&nbsp;&nbsp;&nbsp;');
             }
             pagingOutTabSb.append('</td></tr></table>');
+            var paging = $('#' + options.gridId+'~#'+options.pagingOutTabId);
+            if(null!=paging&&paging.length>0){
+            	paging.remove();
+            }
+
             $('#' + options.gridId).after(pagingOutTabSb.toString());
         },
 


### PR DESCRIPTION
每次绘制翻页工具条时，删除原翻页工具条。
